### PR TITLE
Article action restricted to article owner, refactor to partials, rework authorisation catches

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  before_action :authorized
+  before_action :authorised
   helper_method :current_user
   helper_method :logged_in?
 
@@ -9,10 +9,10 @@ class ApplicationController < ActionController::Base
   end
   
   def logged_in?
-    !current_user.nil?
+    current_user.present?
   end
   
-  def authorized
+  def authorised
     redirect_to login_path unless logged_in?
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,5 +1,8 @@
 class ArticlesController < ApplicationController
-  before_action :set_article, only: [:edit, :update, :show, :destroy]
+  skip_before_action :authorised, only: [:index, :show]
+
+  before_action :set_article, except: [:index, :new, :create]
+  before_action :authorised_for_article_actions, except: [:index, :new, :create, :show]
 
   def index
     @articles = Article.paginate(page: params[:page], per_page: 5)
@@ -50,6 +53,13 @@ class ArticlesController < ApplicationController
 
   def set_article
     @article = Article.find(params[:id])
+  end
+
+  def authorised_for_article_actions
+    unless @article.owned_by?(current_user)
+      flash[:danger] = "You are not authorised to perform that action"
+      redirect_to root_path
+    end
   end
 
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,6 @@
 class PagesController < ApplicationController
-	def index
-	end
+	skip_before_action :authorised, only: [:index]
 
-	def about
+	def index
 	end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,7 @@
 
 class SessionsController < ApplicationController
 
-  skip_before_action :authorized, only: [:new, :create, :welcome]
+  skip_before_action :authorised, only: [:new, :create]
 
   def new
     @user = User.new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-
-  skip_before_action :authorized, only: [:new, :create]
+  skip_before_action :authorised, only: [:index, :new, :create, :show]
 
   def index
     @users = User.all
@@ -24,10 +23,14 @@ class UsersController < ApplicationController
   end
 
   def edit
+    # Note for future
+    # @user = current_user
     @user = User.find(params[:id])
   end
 
   def update
+    # Note for future
+    # @user = current_user
     @user = User.find(params[:id])
     if @user.update(user_params)
       flash[:success] = 'Your account was updated successfully'

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,4 +2,8 @@ class Article < ActiveRecord::Base
   validates :title, presence: true, length: { minimum: 3, maximum: 50 }
   validates :description, presence: true, length: { minimum: 10, maximum: 300 }
   belongs_to :user
+  
+  def owned_by?(user_to_verify)
+    user == user_to_verify
+  end
 end

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,5 +1,11 @@
-<h1>Edit Article</h1>
+<div class="col-xs-8 col-xs-offset-2">
+    <h1>Edit Article</h1>
+</div>
 
 <%= render partial: 'form' %>
-<%= link_to 'Delete', article_path(@article), method: :delete, data: {confirm: "Are you sure?"} %>
-<%= link_to 'Back', articles_path %>
+<div class="row">
+    <div class="col-xs-8 col-xs-offset-2">
+        <%= link_to 'Back', articles_path, class: "btn btn-primary btn-large" %>
+        <%= link_to "Delete", article_path(@article), method: :delete, data: { confirm: "Are you sure you want to delete this article?"}, class: "btn btn-danger btn-large" %>
+    </div>
+</div>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -3,8 +3,7 @@
   <h4 class="center"><strong>Description:</strong></h4>
   <hr>
   <%= simple_format(@article.description) %>
-  <%= link_to "Edit", edit_article_path(@article), class: "btn btn-xs btn-primary" %> 
-  <%= link_to "Delete", article_path(@article), method: :delete, data: { confirm: "Are you sure you want to delete this article?"}, class: "btn btn-xs btn-danger" %>
+  <%= render partial: 'shared/controls', locals: { article: @article } %>
 </div>
 
 <div class="clearfix"></div>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,1 +1,0 @@
-<h1>About Blog</h1>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,1 +1,3 @@
-<h1>Welcome to Blog</h1>
+<div class="col-xs-8 col-xs-offset-2">
+    <h1>Welcome to Blog</h1>
+</div>

--- a/app/views/shared/_article.html.erb
+++ b/app/views/shared/_article.html.erb
@@ -13,12 +13,7 @@
             last updated: <%= time_ago_in_words(article.updated_at) %> ago</small>
         </div>
       </div>
-      <% if current_user == article.user %>
-      <div class="article-actions">
-          <%= link_to "Edit", edit_article_path(article), class: "btn btn-xs btn-primary" %>
-          <%= link_to "Delete", article_path(article), method: :delete, data: { confirm: "Are you sure you want to delete this article?"}, class: "btn btn-xs btn-danger" %>
-      </div>
-      <% end %>
+      <%= render partial: 'shared/controls', locals: { article: article } %>
     </div>
   </div>
 </div>

--- a/app/views/shared/_controls.html.erb
+++ b/app/views/shared/_controls.html.erb
@@ -1,0 +1,6 @@
+<% if article.owned_by?(current_user) %>
+  <div class="article-actions">
+    <%= link_to "Edit", edit_article_path(article), class: "btn btn-xs btn-primary" %>
+    <%= link_to "Delete", article_path(article), method: :delete, data: { confirm: "Are you sure you want to delete this article?"}, class: "btn btn-xs btn-danger" %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-  root 'pages#index'
-  get 'about', to: 'pages#about'
   get 'signup', to: 'users#new'
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
@@ -10,4 +8,5 @@ Rails.application.routes.draw do
   resources :articles
   resources :users, except: [:new]
 
+  root 'pages#index'
 end


### PR DESCRIPTION
* Render article edit & delete controls in a reusable partial

* General tidy up

* Restrict edit, delete and update actions of an article to only the article owner

* We no speak Americano

* Redesign article ownership check, offload logic to model instead of controller

* Corrected extension

* Use new owned by boolean

* Use session present check instead of double negative

* Remove redundant page

* Change authorisation checks, now whitelists actions instead of blacklisting

* Pluralise before action for article actions

* Remove welcome from skip before actions (it does not exist)

* Conform to standards, more root to end of routes file